### PR TITLE
vite config proxy

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'https://URL TO THE CLOUD BACKEND THING',
+        target: 'http://localhost:3000',
         changeOrigin: true,
         secure: true
       }


### PR DESCRIPTION
Now frontend can use http://localhost:3000/api to reach backend